### PR TITLE
Pattern matching

### DIFF
--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 import matplotlib.pyplot as plt
 
-from sampling.sampler import Sampler
+from sampling.sampler import OutputType, Sampler
 
 nlogp = lambda x: 0.5*jnp.sum(jnp.square(x))
 value_grad = jax.value_and_grad(nlogp)
@@ -42,4 +42,4 @@ def test_mclmc():
     assert jnp.array_equal(samples1,samples2), "sampler should be pure"
     assert not jnp.array_equal(samples1,samples3), "this suggests that seed is not being used"
     # run with multiple chains
-    sampler.sample(100, 3)
+    sampler.sample(100, 3, output=OutputType.detailed)


### PR DESCRIPTION
As of 3.10, Python has nice functional pattern matching like Haskell, so we can avoid excessive `if`s.

I also added an Enum (a disjoint sum type), instead of using the type of strings to specify options. This means you don't need to worry about a string being passed in that doesn't match any option, thanks to type safety.

I'll probably do a more thorough version of this sort of refactoring going forward.