### PR TITLE
Target class

### DIFF
--- a/sampling/correlation_length.py
+++ b/sampling/correlation_length.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
-from scipy.fftpack import next_fast_len
+from scipy.fftpack import next_fast_len #type: ignore
 
 
 

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -7,12 +7,26 @@ import numpy as np
 from . import dynamics
 from .correlation_length import ess_corr
 
+class Target():
 
+  def __init__(self, d, nlogp):
+    self.d = d
+    self.nlogp = nlogp
+    self.grad_nlogp = jax.value_and_grad(self.nlogp)
+
+  def transform(self, x):
+    return x
+
+  def prior_draw(self, key):
+    """Args: jax random key
+       Returns: one random sample from the prior"""
+
+    raise Exception("Not implemented")
 
 class Sampler:
     """the MCHMC (q = 0 Hamiltonian) sampler"""
 
-    def __init__(self, Target, L = None, eps = None,
+    def __init__(self, Target : Target, L = None, eps = None,
                  integrator = 'MN', varEwanted = 5e-4,
                  diagonal_preconditioning= False,
                  frac_tune1 = 0.1, frac_tune2 = 0.1, frac_tune3 = 0.1,

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -28,6 +28,7 @@ class StandardGaussian(Target):
 target = StandardGaussian(d = 10, nlogp=nlogp)
 sampler = Sampler(target, varEwanted = 5e-4)
 
+target_simple = Target(d = 10, nlogp=nlogp)
 
 def test_mclmc():
     samples1 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(0))
@@ -37,3 +38,5 @@ def test_mclmc():
     assert not jnp.array_equal(samples1,samples3), "this suggests that seed is not being used"
     # run with multiple chains
     sampler.sample(100, 3)
+
+    Sampler(target).sample(100, x_initial = jax.random.normal(shape=(10,), key=jax.random.PRNGKey(0)))

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -7,31 +7,25 @@ import jax.numpy as jnp
 import numpy as np
 import matplotlib.pyplot as plt
 
-from sampling.sampler import Sampler
+from sampling.sampler import Sampler, Target
 
 nlogp = lambda x: 0.5*jnp.sum(jnp.square(x))
-value_grad = jax.value_and_grad(nlogp)
 
-class StandardGaussian():
+class StandardGaussian(Target):
 
-  def __init__(self, d):
-    self.d = d
-
-  def grad_nlogp(self, x):
-    """should return nlogp and gradient of nlogp"""
-    return value_grad(x)
+  def __init__(self, d, nlogp):
+    Target.__init__(self,d,nlogp)
 
   def transform(self, x):
     return x[:2]
-    #return x
-
+  
   def prior_draw(self, key):
     """Args: jax random key
        Returns: one random sample from the prior"""
 
     return jax.random.normal(key, shape = (self.d, ), dtype = 'float64') * 4
 
-target = StandardGaussian(d = 10)
+target = StandardGaussian(d = 10, nlogp=nlogp)
 sampler = Sampler(target, varEwanted = 5e-4)
 
 

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -39,4 +39,4 @@ def test_mclmc():
     # run with multiple chains
     sampler.sample(100, 3)
 
-    Sampler(target).sample(100, x_initial = jax.random.normal(shape=(10,), key=jax.random.PRNGKey(0)))
+    Sampler(target_simple).sample(100, x_initial = jax.random.normal(shape=(10,), key=jax.random.PRNGKey(0)))


### PR DESCRIPTION
It seems like it would make sense to add a `Target` class, from which any given target would inherit. This makes the process of running the sampler quicker for a simple case, like the following, without having to write a new class:

```python
import jax
from sampling.sampler import Sampler, Target

target_simple = Target(d = 10, nlogp=lambda x: 0.5*jnp.sum(jnp.square(x)))
Sampler(target_simple).sample(100, x_initial = jax.random.normal(shape=(10,), key=jax.random.PRNGKey(0)))
```