### PR TITLE
Refactoring

### DIFF
--- a/sampling/dynamics.py
+++ b/sampling/dynamics.py
@@ -5,7 +5,6 @@ import math
 
 lambda_c = 0.1931833275037836 #critical value of the lambda parameter for the minimal norm integrator
 
-grad_evals = {'MN' : 2, 'LF' : 1}
 
 
 
@@ -169,3 +168,6 @@ def partially_refresh_momentum(d, sequential= True):
 
 
   return rng_sequential if sequential else rng_parallel
+
+
+grad_evals = {minimal_norm : 2, leapfrog : 1}

--- a/sampling/dynamics.py
+++ b/sampling/dynamics.py
@@ -92,22 +92,6 @@ def leapfrog(d, T, V):
 
 
 
-def hamiltonian(integrator, grad_nlogp, d, sequential = True):
-    
-    T = update_position(grad_nlogp)
-    V = update_momentum(d, sequential)
-    
-    if integrator == "LF": #leapfrog (first updates the velocity)
-        return leapfrog(d, T, V)
-
-    elif integrator== 'MN': #minimal norm integrator (first updates the velocity)
-        return minimal_norm(d, T, V)
-      
-    else:
-        raise Exception("Integrator must be either MN (minimal_norm) or LF (leapfrog)")
-
-
-
 def mclmc(hamiltonian_dynamics, partially_refresh_momentum, d):
     
   def step(x, u, g, random_key, L, eps, sigma):

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -268,24 +268,40 @@ class Sampler:
 
         ### sampling ###
 
-        if output == OutputType.normal or output == OutputType.detailed:
-            X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
-            if output == 'detailed':
-                return X, E, L, eps
-            else:
+        match output:
+            case OutputType.normal:
+                X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
                 return X
-        elif output == OutputType.expectation:
-            return self.sample_expectation(num_steps, x, u, l, g, key, L, eps, sigma)
+            case OutputType.detailed:
+                X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
+                return X, E, L, eps
+            case OutputType.expectation:
+                return self.sample_expectation(num_steps, x, u, l, g, key, L, eps, sigma)
+            case OutputType.ess:
+                try:
+                    self.Target.variance
+                except:
+                    raise AttributeError("Target.variance should be defined")
+                return self.sample_ess(num_steps, x, u, l, g, key, L, eps, sigma)
 
-        elif output == OutputType.ess:
-            try:
-                self.Target.variance
-            except:
-                raise AttributeError("Target.variance should be defined")
-            return self.sample_ess(num_steps, x, u, l, g, key, L, eps, sigma)
+        # if output == OutputType.normal or output == OutputType.detailed:
+        #     X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
+        #     if output == 'detailed':
+        #         return X, E, L, eps
+        #     else:
+        #         return X
+        # elif output == OutputType.expectation:
+        #     return self.sample_expectation(num_steps, x, u, l, g, key, L, eps, sigma)
 
-        else:
-            raise ValueError('output = ' + output + ' is not a valid argument for the Sampler.sample')
+        # elif output == OutputType.ess:
+        #     try:
+        #         self.Target.variance
+        #     except:
+        #         raise AttributeError("Target.variance should be defined")
+        #     return self.sample_ess(num_steps, x, u, l, g, key, L, eps, sigma)
+
+        # else:
+        #     raise ValueError('output = ' + output + ' is not a valid argument for the Sampler.sample')
 
 
     ### for loops which do the sampling steps: ###

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -1,7 +1,9 @@
 import sys
 
 from pytest import raises
-import pytest  
+import pytest
+
+from sampling.dynamics import leapfrog  
 sys.path.insert(0, '../../')
 sys.path.insert(0, './')
 
@@ -45,15 +47,15 @@ def test_mclmc():
     # run with multiple chains
     sampler.sample(20, 3)
     # run with different output types
-    sampler.sample(20, 3, output=OutputType.expectation)
-    sampler.sample(20, 3, output=OutputType.detailed)
-    sampler.sample(20, 3, output=OutputType.normal)
+    sampler.sample(20, 1, output=OutputType.expectation)
+    sampler.sample(20, 1, output=OutputType.detailed)
+    sampler.sample(20, 1, output=OutputType.normal)
 
     with raises(AttributeError) as excinfo:
-        sampler.sample(20, 3, output=OutputType.ess)
+        sampler.sample(20, 1, output=OutputType.ess)
 
     # run with leapfrog
-    sampler = Sampler(target, varEwanted = 5e-4, integrator='LF')
+    sampler = Sampler(target, varEwanted = 5e-4, integrator=leapfrog)
     sampler.sample(20)
     # run without autotune
     sampler = Sampler(target, varEwanted = 5e-4, frac_tune1 = 0.1, frac_tune2 = 0.1, frac_tune3 = 0.1,)

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 import matplotlib.pyplot as plt
 
-from sampling.sampler import Sampler, Target
+from sampling.sampler import OutputType, Sampler, Target
 
 nlogp = lambda x: 0.5*jnp.sum(jnp.square(x))
 
@@ -45,12 +45,12 @@ def test_mclmc():
     # run with multiple chains
     sampler.sample(20, 3)
     # run with different output types
-    sampler.sample(20, 3, output='expectation')
-    sampler.sample(20, 3, output='detailed')
-    sampler.sample(20, 3, output='normal')
+    sampler.sample(20, 3, output=OutputType.expectation)
+    sampler.sample(20, 3, output=OutputType.detailed)
+    sampler.sample(20, 3, output=OutputType.normal)
 
     with raises(AttributeError) as excinfo:
-        sampler.sample(20, 3, output='ess')
+        sampler.sample(20, 3, output=OutputType.ess)
 
     # run with leapfrog
     sampler = Sampler(target, varEwanted = 5e-4, integrator='LF')


### PR DESCRIPTION
I wrote a few refactors, to remove a bit of code. 

I don't know if this will break anything on @JakobRobnik 's ensemble branch, so you should probably try merging it in, and checking.

Main changes:

1. output == "normal" -> output == OutputType.normal: this way you don't pass in arbitrary strings as arguments. The possible options are given by `OutputType = Enum('Output', ['normal', 'detailed', 'expectation', 'ess'])`
2. Instead of passing in 'MN' or 'LF', directly pass in the integrator function. This meant I could remove `hamiltonian` entirely.
3. `if ... else` replaced in some places by `case`, e.g.

```python
match output:
            case OutputType.normal:
                X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
                return X
            case OutputType.detailed:
                X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
                return X, E, L, eps
...
``` 