### PR TITLE
Better Benchmarking

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,4 +31,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest
+        make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.benchmarks
 .pytest*
 */__pycache__/*
 *__pycache__*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-## How to contribute to MCHMC
+# How to contribute to MCHMC
+
+## Bugs
 
 ### Did you find a bug?
 
@@ -16,9 +18,18 @@ Open a new GitHub pull request with the patch. Ensure the PR description
 clearly describes the problem and solution. Include the relevant issue number
 if applicable.
 
-### Do you intend to add a new feature or change an existing one?
+## Do you intend to add a new feature or change an existing one?
 
 First, [open a new issue](https://github.com/JakobRobnik/MicroCanonicalHMC/issues/new) and
 clearly describe your idea. We will then let you know if what you suggest 
 aligns with the vision of MCHMC. This way you might avoid doing unnecessary
 work and might even find some help from other people.
+
+### Contribution Workflow
+
+1. Checkout a new branch.
+2. Run `make set-bench` to determine the speed of the current version of the code on your computer.
+3. Add your feature on a new branch
+4. Run `make test` to run tests locally.
+5. Run `make compare-bench` to see if your changes slowed the code.
+6. Push the branch and open a pull request. Assign a developer.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 PKG_VERSION = $(shell python setup.py --version)
 
 test:
-	JAX_PLATFORM_NAME=cpu pytest
+	JAX_PLATFORM_NAME=cpu pytest --benchmark-disable
+
+set-bench:
+	pytest --benchmark-autosave  
+
+compare-bench:
+	pytest --benchmark-compare=0001 --benchmark-compare-fail=mean:2%
 
 # We launch the package release by tagging the master branch with the package's
-# new version number. The version number is read from `blackjax/__init__.py`
+# new version number.
 release:
 	git tag -a $(PKG_VERSION) -m $(PKG_VERSION)
 	git push --tag

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ matplotlib
 pandas
 jaxlib
 jax
+pytest
+pytest-benchmark

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from pytest import raises
 import pytest
@@ -29,6 +30,8 @@ class StandardGaussian(Target):
        Returns: one random sample from the prior"""
 
     return jax.random.normal(key, shape = (self.d, ), dtype = 'float64') * 4
+
+
 
 
 
@@ -74,3 +77,14 @@ def test_mclmc():
     # simple target
     target_simple = Target(d = 10, nlogp=nlogp)
     Sampler(target_simple).sample(100, x_initial = jax.random.normal(shape=(10,), key=jax.random.PRNGKey(0)))
+
+# speed
+def gaussian():
+    d = 1000
+    target_simple = Target(d = d, nlogp=nlogp)
+    samples = Sampler(target_simple).sample(100000, x_initial = jax.random.normal(shape=(d,), key=jax.random.PRNGKey(0)))
+    return samples
+
+def test_speed(benchmark):
+    result = benchmark(gaussian)
+    assert jnp.abs(jnp.mean(result))<1e-3


### PR DESCRIPTION
I wanted to make the speed benchmarking more automated. Here's how it works:

1. On the master branch, run `make set-bench`. This will run a multivariate Gaussian several times, and create a (gitignored) file saving info about the run and your machine. Because it's gitignored, it will just stay on your machine, even when you change branches.
2. Once you've made a change, on a new branch, run `make compare-bench`. This will run the same Gaussian, and if it's on average more than 2% slower than the existing benchmark, it will fail.

For example, I might attempt some refactoring of the code in the future, and if I do, I will follow the above. That way, I can be sure that the code is not significantly slower.