### PR TITLE
Kernel refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PKG_VERSION = $(shell python setup.py --version)
 
 test:
 	JAX_PLATFORM_NAME=cpu pytest --benchmark-disable
+	mypy sampling/sampler.py
 
 set-bench:
 	pytest --benchmark-autosave  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+mypy
 pre-commit
 numpy
 matplotlib

--- a/sampling/dynamics.py
+++ b/sampling/dynamics.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any, NamedTuple
-from chex import ArrayTree
 import jax
+from jax import Array
 import jax.numpy as jnp
 import numpy as np
 import math
@@ -13,17 +13,17 @@ class MCLMCState(NamedTuple):
 
     """
 
-    x: ArrayTree
-    u: ArrayTree
+    x: Array
+    u: Array
     l: float
-    g: ArrayTree
+    g: Array
     key : Any
 
 class MCLMCInfo(NamedTuple):
 
 
-    transformed_x: ArrayTree
-    l: ArrayTree
+    transformed_x: Array
+    l: Array
     de: float
 
 def update_momentum(d, sequential):

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -321,11 +321,11 @@ class Sampler:
 
     
 
-    def sample_normal(self, num_steps : int, state, params : Parameters, thinning : int) -> MCLMCInfo:
+    def sample_normal(self, num_steps : int, state : MCLMCState, params : Parameters, thinning : int) -> MCLMCInfo:
         """Stores transform(x) for each step."""
 
+        kernel = build_kernel(self.Target, self.integrator, params=params)
         if thinning == 1:
-            kernel = build_kernel(self.Target, self.integrator, params=params)
             return run_kernel(kernel=kernel, num_steps=num_steps, initial_state=state)
 
         else:

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from typing import NamedTuple
-from chex import Array
+from jax import Array
 import jax
 import jax.numpy as jnp
 import numpy as np

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -1,11 +1,14 @@
 ## style note: general preference here for functional style (e.g. global function definitions, purity, code sharing)
 
 from enum import Enum
+from typing import NamedTuple
+from chex import Array
 import jax
 import jax.numpy as jnp
 import numpy as np
+from sampling import dynamics
 
-from . import dynamics
+from sampling.dynamics import MCLMCInfo, MCLMCState, build_kernel, run_kernel
 from .correlation_length import ess_corr
 
 class Target():
@@ -44,6 +47,14 @@ class Target():
 OutputType = Enum('Output', ['normal', 'detailed', 'expectation', 'ess'])
 """ @private """
 
+class Parameters(NamedTuple):
+    """Tunable parameters
+    """
+
+    L: float
+    eps: float
+    sigma: Array
+
 class Sampler:
     """the MCHMC (q = 0 Hamiltonian) sampler"""
 
@@ -80,8 +91,10 @@ class Sampler:
         """@private"""
         self.sigma = jnp.ones(Target.d)
 
+        self.integrator = integrator
+
         ### integrator ###
-        hamiltonian_step, self.grad_evals_per_step = integrator(T= dynamics.update_position(self.Target.grad_nlogp), 
+        hamiltonian_step, self.grad_evals_per_step = self.integrator(T= dynamics.update_position(self.Target.grad_nlogp), 
                                                                 V= dynamics.update_momentum(self.Target.d, sequential=True),
                                                                 d= self.Target.d)
         self.dynamics = dynamics.mclmc(hamiltonian_step, dynamics.partially_refresh_momentum(self.Target.d, True), self.Target.d)
@@ -288,7 +301,7 @@ class Sampler:
 
         
         if output == OutputType.normal or output == OutputType.detailed:
-            X, _, E = self.sample_normal(num_steps, x, u, l, g, key, L, eps, sigma, thinning)
+            X, _, E = self.sample_normal(num_steps, MCLMCState(x, u, l, g, key), Parameters(L, eps, sigma), thinning)
             if output == OutputType.detailed:
                 return X, E, L, eps
             else:
@@ -306,37 +319,28 @@ class Sampler:
        
     ### for loops which do the sampling steps: ###
 
-    def sample_normal(self, num_steps, x, u, l, g, random_key, L, eps, sigma, thinning):
+    
+
+    def sample_normal(self, num_steps : int, state, params : Parameters, thinning : int) -> MCLMCInfo:
         """Stores transform(x) for each step."""
-        
-        def step(state, useless):
-
-            x, u, l, g, key = state
-            xx, uu, ll, gg, kinetic_change, key = self.dynamics(x, u, g, key, L, eps, sigma)
-
-            # left in as a comment since it may be useful when experimenting with neighbour lists in MD
-            # if self.Target.nbrs:
-            #     self.Target.nbrs = self.Target.nbrs.update(jnp.reshape(xx, (-1,3)), neighbor=self.Target.nbrs)
-            
-            de = kinetic_change + ll - l
-            
-            return (xx, uu, ll, gg, key), (self.Target.transform(xx), ll, de)
-
 
         if thinning == 1:
-            return jax.lax.scan(step, init=(x, u, l, g, random_key), xs=None, length=num_steps)[1]
+            kernel = build_kernel(self.Target, self.integrator, params=params)
+            return run_kernel(kernel=kernel, num_steps=num_steps, initial_state=state)
 
         else:
-            return self.sample_thinning(num_steps, x, u, l, g, random_key, L, eps, sigma, thinning)
+            x,u,l,g,random_key = state
+            return self.sample_thinning(num_steps, x, u, l, g, random_key, params, thinning)
 
 
-    def sample_thinning(self, num_steps, x, u, l, g, random_key, L, eps, sigma, thinning):
+    def sample_thinning(self, num_steps, x, u, l, g, random_key, params, thinning):
         """Stores transform(x) for each step."""
 
-        def step(state, useless):
+        def step(state, _):
 
-            def substep(state, useless):
+            def substep(state, _):
                 x, u, l, g, _, key = state
+                L,eps,sigma = params
                 xx, uu, ll, gg, kinetic_change, key = self.dynamics(x, u, g, key, L, eps, sigma)
                 de = kinetic_change + ll - l
                 return (xx, uu, ll, gg, de, key), None

--- a/sampling/sampler.py
+++ b/sampling/sampler.py
@@ -321,7 +321,7 @@ class Sampler:
 
     
 
-    def sample_normal(self, num_steps : int, state : MCLMCState, params : Parameters, thinning : int) -> MCLMCInfo:
+    def sample_normal(self, num_steps : int, state : MCLMCState, params : Parameters, thinning : int):
         """Stores transform(x) for each step."""
 
         kernel = build_kernel(self.Target, self.integrator, params=params)

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -40,8 +40,6 @@ def test_mclmc():
     sampler = Sampler(target, varEwanted = 5e-4)
 
     samples1 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(0))
-    print(samples1)
-
     samples2 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(0))
     samples3 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(1))
     assert jnp.array_equal(samples1,samples2), "sampler should be pure"
@@ -89,6 +87,3 @@ def gaussian():
 def test_speed(benchmark):
     result = benchmark(gaussian)
     assert jnp.abs(jnp.mean(result))<1e-3
-
-
-test_mclmc()

--- a/tests/test_mclmc.py
+++ b/tests/test_mclmc.py
@@ -4,9 +4,9 @@ import time
 from pytest import raises
 import pytest
 
-from sampling.dynamics import leapfrog  
 sys.path.insert(0, '../../')
 sys.path.insert(0, './')
+from sampling.dynamics import leapfrog  
 
 import jax
 import jax.numpy as jnp
@@ -39,8 +39,9 @@ def test_mclmc():
     target = StandardGaussian(d = 10, nlogp=nlogp)
     sampler = Sampler(target, varEwanted = 5e-4)
 
-
     samples1 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(0))
+    print(samples1)
+
     samples2 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(0))
     samples3 = sampler.sample(100, 1, random_key=jax.random.PRNGKey(1))
     assert jnp.array_equal(samples1,samples2), "sampler should be pure"
@@ -88,3 +89,6 @@ def gaussian():
 def test_speed(benchmark):
     result = benchmark(gaussian)
     assert jnp.abs(jnp.mean(result))<1e-3
+
+
+test_mclmc()


### PR DESCRIPTION
I thought it would be nice to take the BlackJax approach, and be explicit about the kernel as a function of type:

```
MCMCState -> (MCMCState, MCMCInfo)
```

More concretely, I have introduced:

```python
class MCLMCState(NamedTuple):
    """State of the MCLMC algorithm.

    """

    x: ArrayTree
    u: ArrayTree
    l: float
    g: ArrayTree
    key : Any

class MCLMCInfo(NamedTuple):


    transformed_x: ArrayTree
    l: ArrayTree
    de: float
```

I've only refactored for `sample_normal`, but it could easily be extended everywhere.

This should make adding to BlackJax easier, but I think also clarifies the information flow of the code somewhat.